### PR TITLE
Downgrade to documentjs 0.4.x

### DIFF
--- a/default/index.js
+++ b/default/index.js
@@ -20,7 +20,7 @@ module.exports = Generator.extend({
   },
 
   installingDocumentJS: function() {
-    this.npmInstall(['documentjs'], { 'saveDev': true });
+    this.npmInstall(['documentjs@0.4.x'], { 'saveDev': true });
   },
 
   prompting: function () {


### PR DESCRIPTION
This downgrades to documentjs 0.4.x because of
https://github.com/bitovi/documentjs/issues/282